### PR TITLE
Fix type mismatch in calls to gsl_histogram(2d)?_find

### DIFF
--- a/lib/Math/Libgsl/Histogram.rakumod
+++ b/lib/Math/Libgsl/Histogram.rakumod
@@ -53,7 +53,7 @@ method bins(--> UInt) { gsl_histogram_bins($!h) }
 method reset() { gsl_histogram_reset($!h) }
 # Search histogram ranges
 method find(Num() $x --> UInt) {
-  my int32 $bin;
+  my size_t $bin;
   my $ret = gsl_histogram_find($!h, $x, $bin);
   fail X::Libgsl.new: errno => $ret, error => "Can't find bin" if $ret ≠ GSL_SUCCESS;
   $bin

--- a/lib/Math/Libgsl/Histogram2D.rakumod
+++ b/lib/Math/Libgsl/Histogram2D.rakumod
@@ -65,7 +65,7 @@ method ny(--> UInt)  { gsl_histogram2d_ny($!h) }
 method reset()       { gsl_histogram2d_reset($!h) }
 # Search histogram ranges
 method find(Num() $x, Num() $y --> List) {
-  my int32 ($i, $j);
+  my size_t ($i, $j);
   my $ret = gsl_histogram2d_find($!h, $x, $y, $i, $j);
   fail X::Libgsl.new: errno => $ret, error => "Can't find bin" if $ret ≠ GSL_SUCCESS;
   $i, $j;

--- a/t/01-raw-1d.rakutest
+++ b/t/01-raw-1d.rakutest
@@ -38,7 +38,7 @@ subtest 'updating, accessing, and searching elements' => {
   ok gsl_histogram_max($h) == 1000, 'max bin limit';
   ok gsl_histogram_min($h) == 1, 'min bin limit';
   ok gsl_histogram_bins($h) == 3, 'number of bins';
-  my int32 $bin;
+  my size_t $bin;
   gsl_histogram_find($h, 18e0, $bin);
   ok $bin == 1, 'find bin number';
   gsl_histogram_reset($h);

--- a/t/02-raw-2d.rakutest
+++ b/t/02-raw-2d.rakutest
@@ -44,7 +44,7 @@ subtest 'updating, accessing, and searching elements' => {
   ok gsl_histogram2d_ymin($h) == 2, 'min y bin limit';
   ok gsl_histogram2d_nx($h) == 3, 'number of x bins';
   ok gsl_histogram2d_ny($h) == 3, 'number of y bins';
-  my int32 ($xbin, $ybin);
+  my size_t ($xbin, $ybin);
   gsl_histogram2d_find($h, 18e0, 22e0, $xbin, $ybin);
   ok $xbin == 1 && $ybin == 1, 'find x and y bin number';
   gsl_histogram2d_reset($h);


### PR DESCRIPTION
The last argument(s) are size_t, which is an unsigned integer. The next
Rakudo version will finally have proper support for unsigned ints, which
means that it also knows the difference between int and uint and will
complain if given the wrong one. Furthermore on 64 bit systems size_t is
usually 64 bit large. Since the exact size is platform dependent, using
size_t directly as argument type is just a better idea anyway.

This is required for Rakudo 2022.02 and up. The fix is backwards
compatible.